### PR TITLE
Fixed civicrm and drupal settings to use :

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       - buildkit:/buildkit/civicrm-buildkit
       - ./build:/buildkit/build
       - ./extra:/extra
-      - ./drupal-settings /etc/drupal-settings.d
-      - ./civicrm-settings /etc/civicrm-settings.d
+      - ./drupal-settings:/etc/drupal-settings.d
+      - ./civicrm-settings:/etc/civicrm-settings.d
       - amp:/buildkit/.amp
       - bower-cache:/buildkit/.cache/bower
       - composer-cache:/buildkit/.composer


### PR DESCRIPTION
This fixed the error I was getting "invalid mount config for type "volume": invalid mount path: 'drupal-settings /etc/drupal-settings.d' mount path must be absolute".